### PR TITLE
Fixed Searchbar close issue & added duplicate check in ImportContacts

### DIFF
--- a/app/src/main/java/com/community/jboss/leadmanagement/main/contacts/ContactsAdapter.java
+++ b/app/src/main/java/com/community/jboss/leadmanagement/main/contacts/ContactsAdapter.java
@@ -36,7 +36,6 @@ public class ContactsAdapter extends RecyclerView.Adapter<ContactsAdapter.ViewHo
     private ContactsAdapter mAdapter;
     public AdapterListener mListener;
     private List<Contact> spareData;
-    public int sizeOfArray;
 
     public ContactsAdapter(AdapterListener listener) {
         mListener = listener;
@@ -91,8 +90,6 @@ public class ContactsAdapter extends RecyclerView.Adapter<ContactsAdapter.ViewHo
                         filteredList.add(contact);
                     }
                 }
-                
-                sizeOfArray = filteredList.size();
 
                 FilterResults results = new FilterResults();
                 results.values = filteredList;
@@ -234,6 +231,10 @@ public class ContactsAdapter extends RecyclerView.Adapter<ContactsAdapter.ViewHo
             deleteButton.setVisibility(newVisibility);
             return true;
         }
+    }
+
+    public int getDataSize(){
+        return mContacts.size();
     }
 }
 

--- a/app/src/main/java/com/community/jboss/leadmanagement/main/contacts/ContactsFragment.java
+++ b/app/src/main/java/com/community/jboss/leadmanagement/main/contacts/ContactsFragment.java
@@ -1,9 +1,11 @@
 package com.community.jboss.leadmanagement.main.contacts;
 
+import android.animation.LayoutTransition;
 import android.arch.lifecycle.ViewModelProviders;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.v4.widget.SwipeRefreshLayout;
+import android.support.v7.app.ActionBar;
 import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.Menu;
@@ -78,6 +80,29 @@ public class ContactsFragment extends MainFragment implements ContactsAdapter.Ad
         searchView.setSubmitButtonEnabled(false);
         searchView.setQueryRefinementEnabled(false);
         searchView.setOnQueryTextListener(this);
+        searchMenuItem.setOnActionExpandListener(new MenuItem.OnActionExpandListener() {
+            @Override
+            public boolean onMenuItemActionExpand(MenuItem item) {
+                if(item==searchMenuItem){
+                    mAdapter.getFilter().filter(searchView.getQuery());
+                    if( mAdapter.getDataSize() == 0){
+                        textView.setVisibility(View.VISIBLE);
+                    } else{
+                        textView.setVisibility(View.GONE);
+                    }
+                }
+                return true;
+            }
+
+            @Override
+            public boolean onMenuItemActionCollapse(MenuItem item) {
+                if(item==searchMenuItem){
+                    mAdapter.getFilter().filter("");
+                    textView.setVisibility(View.GONE);
+                }
+                return true;
+            }
+        });
     }
 
     @Override
@@ -112,7 +137,7 @@ public class ContactsFragment extends MainFragment implements ContactsAdapter.Ad
     @Override
     public boolean onQueryTextChange(String newText) {
         mAdapter.getFilter().filter(newText);
-        if (mAdapter.sizeOfArray == 0){
+        if (mAdapter.getDataSize() == 0){
             textView.setVisibility(View.VISIBLE);
         }
         else {

--- a/app/src/main/java/com/community/jboss/leadmanagement/main/contacts/importcontact/ImportContactActivity.java
+++ b/app/src/main/java/com/community/jboss/leadmanagement/main/contacts/importcontact/ImportContactActivity.java
@@ -99,8 +99,10 @@ public class ImportContactActivity extends AppCompatActivity {
                         .replace(")","")
                         .replace(" ","")
                         .replace("-","");
-                ImportContact contact = new ImportContact(name,number);
-                contacts.add(contact);
+                if(numberDao.getContactNumber(number)==null) {
+                    ImportContact contact = new ImportContact(name, number);
+                    contacts.add(contact);
+                }
             } while (people.moveToNext());
         }
         return contacts;


### PR DESCRIPTION
Changes:
- [Video preview of issue](https://youtu.be/TY95qwnWzx0) TextView of no resul found was still staying when clearing searchview using X 
- [Video preview of issue, (If it is an issue)](https://www.youtube.com/watch?v=38khQ916Bfs)on searchview close using <- recyclerview data was still filtered. (if it's not an issue will take it out.)
- added getter of adapter data size, instead of variable.
- [Video preview](https://www.youtube.com/watch?v=CWDlTmag9mo&feature=youtu.be) Added duplicate check in ImportContacts (means that if mobile contact is already imported into app, that contact will not be visible in "importable contacts") to prevent duplicate contacts in app.
